### PR TITLE
Print test:stdout and test:stderr's messages

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -28,7 +28,9 @@ export default async function * customReporter (source) {
       type !== 'test:pass' &&
       type !== 'test:fail' &&
       type !== 'test:plan' &&
-      type !== 'test:diagnostic'
+      type !== 'test:diagnostic' &&
+      type !== 'test:stdout' &&
+      type !== 'test:stderr'
     ) {
       continue;
     }
@@ -110,6 +112,12 @@ export default async function * customReporter (source) {
       case 'test:diagnostic':
         // Emitted when context.diagnostic is called.
         diagnostics.push(data);
+        break;
+      case 'test:stdout':
+        process.stdout.write(data.message);
+        break;
+      case 'test:stderr':
+        process.stderr.write(data.message);
         break;
     }
   }


### PR DESCRIPTION
Not sure if this was intentional, but in case it wasn't, here's a fix.

Fixes https://github.com/voxpelli/node-test-pretty-reporter/issues/16